### PR TITLE
linux: avoid spurious warnings from make

### DIFF
--- a/mk/linux.mk
+++ b/mk/linux.mk
@@ -27,11 +27,11 @@ endif
 OBJECTS=$(CFILES:.c=.o)
 
 all: $(OBJECTS)
-	-mkdir bin
+	-mkdir -p bin
 	$(CC)  -o bin/warpd $(OBJECTS) $(CFLAGS)
 clean:
-	-rm $(OBJECTS)
-	-rm -r bin
+	-rm -f $(OBJECTS)
+	-rm -rf bin
 install:
 	mkdir -p $(DESTDIR)$(PREFIX)/share/man/man1/ $(DESTDIR)$(PREFIX)/bin/
 	install -m644 files/warpd.1.gz $(DESTDIR)$(PREFIX)/share/man/man1/


### PR DESCRIPTION
If the artifacts to clean don't exist, `rm(1)` will emit a warning which may worry the user.  But there is nothing to worry about, so silence the warning with the `-f` flag.

Similarly, if the bin/ directory already exists, `mkdir(1)` will emit an unnecessary warning, so add the `-p` flag.