### PR TITLE
Add pointer to documentation and configuration to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,14 @@ Available in the [AUR](https://aur.archlinux.org/): [warpd](https://aur.archlinu
 
 If you are interesting in adding warpd to your distribution's repository please contact me.
 
+# Documentation / Configuration
+
+Documentation and configuration options can be found with:
+
+```
+warpd --list-options
+```
+
 # Limitations/Bugs
 
 - Programs which use Xinput and or Xtest for keyboard may not work correctly


### PR DESCRIPTION
As a first time user I was unable to find any docs or config options until a user pointed me to a single command which must be entered to discover more; I thought this should be available to all for a better experience.

I have included a small section describing how to get the docs/config options at the bottom of the README.