### PR TITLE
Fix typename typo `input_evnet` should be ` input_event`

### DIFF
--- a/src/platform/linux/X/input.c
+++ b/src/platform/linux/X/input.c
@@ -366,7 +366,7 @@ struct input_event *x_input_wait(struct input_event *events, size_t sz)
 {
 	size_t i;
 	static struct input_event ev;
-	struct input_evnet *ret = NULL;
+	struct input_event *ret = NULL;
 
 	for (i = 0; i < sz; i++) {
 		struct input_event *ev = &events[i];


### PR DESCRIPTION
## The problem

In commit ` 189bffe047ef78b01f011ef367c7d3d841d06452`.  
In `src/platform/linux/X/input.c:369`, the type of `ret` should be `struct input_event *` rather than `struct input_evnet *`.

This causes a incompatible point type error on line 386 when assigning `&ev` to `ret`, raising the following compilation error (on gcc 14.1.1)

```plaintext
src/platform/linux/X/input.c: In function ‘x_input_wait’:
src/platform/linux/X/input.c:386:29: error: assignment to ‘struct input_evnet *’ from incompatible pointer type ‘struct input_event *’ [-Wincompatible-pointer-types]
  386 |                         ret = &ev;
      |                             ^
src/platform/linux/X/input.c:406:16: error: returning ‘struct input_evnet *’ from a function with incompatible return type ‘struct input_event *’ [-Wincompatible-pointer-types]
  406 |         return ret;
      |   
```


## The fix

```diff
diff --git a/src/platform/linux/X/input.c b/src/platform/linux/X/input.c
index ba3aca5..9f75fac 100644
--- a/src/platform/linux/X/input.c
+++ b/src/platform/linux/X/input.c
@@ -366,7 +366,7 @@ struct input_event *x_input_wait(struct input_event *events, size_t sz)
 {
        size_t i;
        static struct input_event ev;
-       struct input_evnet *ret = NULL;
+       struct input_event *ret = NULL;

        for (i = 0; i < sz; i++) {
                struct input_event *ev = &events[i];
```