### PR TITLE
windows: add manifest to executable for high DPI awareness

### DIFF
--- a/src/windows/build.bat
+++ b/src/windows/build.bat
@@ -1,4 +1,5 @@
 cd /D "%~dp0"
 mkdir obj
 cl /Foobj\ /Fe:warpd.exe *.c icon.res ..\config.c ..\daemon.c ..\grid.c ..\grid_drw.c ..\hint.c ..\histfile.c ..\history.c ..\input.c ..\mode-loop.c ..\mouse.c ..\normal.c ..\screen.c ..\scroll.c ..\platform\windows\*.c user32.lib gdi32.lib shell32.lib
+mt.exe -manifest warpd.exe.manifest -outputresource:warpd.exe;1
 rmdir /s /q obj

--- a/src/windows/warpd.exe.manifest
+++ b/src/windows/warpd.exe.manifest
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+  <asmv3:application>
+    <asmv3:windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </asmv3:windowsSettings>
+  </asmv3:application>
+</assembly>


### PR DESCRIPTION
Hello!

Under Windows the tray popup menu and "warpd is already running" messagebox look scary when using interface scaling different from 100% (which is almost always true for high-DPI displays).

This patch resolves this by rejecting Windows' scaling feature.
It is done by manifest embedding with dpiAware and dpiAwareness settings, the former is for pre-win10 systems, the latter is for Win10+
