### PR TITLE
Make project available as a systemd service

### DIFF
--- a/files/warpd.service
+++ b/files/warpd.service
@@ -1,0 +1,7 @@
+[Install]
+WantedBy=default.target
+
+[Service]
+Type=simple
+# `-f` option is to make output go to journald
+ExecStart=warpd -f

--- a/mk/linux.mk
+++ b/mk/linux.mk
@@ -35,9 +35,11 @@ clean:
 install:
 	mkdir -p $(DESTDIR)$(PREFIX)/share/man/man1/ $(DESTDIR)$(PREFIX)/bin/
 	install -m644 files/warpd.1.gz $(DESTDIR)$(PREFIX)/share/man/man1/
+	install -m644 files/warpd.service $(DESTDIR)/etc/systemd/user/
 	install -m755 bin/warpd $(DESTDIR)$(PREFIX)/bin/
 uninstall:
-	rm $(DESTDIR)$(PREFIX)/share/man/man1/warpd.1.gz\
-		$(DESTDIR)$(PREFIX)/bin/warpd
+	rm $(DESTDIR)$(PREFIX)/share/man/man1/warpd.1.gz \
+		$(DESTDIR)$(PREFIX)/bin/warpd \
+		$(DESTDIR)/etc/systemd/user/warpd.service
 
 .PHONY: all platform assets install uninstall bin


### PR DESCRIPTION
This provides a systemd service file, so users wouldn't need to write one themselves and could just use it along with the project right away.