### PR TITLE
X: fix struct type typo

### DIFF
--- a/src/platform/linux/X/input.c
+++ b/src/platform/linux/X/input.c
@@ -366,7 +366,7 @@ struct input_event *x_input_wait(struct input_event *events, size_t sz)
 {
 	size_t i;
 	static struct input_event ev;
-	struct input_evnet *ret = NULL;
+	struct input_event *ret = NULL;
 
 	for (i = 0; i < sz; i++) {
 		struct input_event *ev = &events[i];


### PR DESCRIPTION
Before, `make` fails like this:

```
rc/platform/linux/X/input.c: In function ‘x_input_wait’:
src/platform/linux/X/input.c:386:29: error: assignment to ‘struct input_evnet *’ from incompatible pointer type ‘struct input_event *’ [-Wincompatible-pointer-types]
  386 |                         ret = &ev;
      |                             ^
src/platform/linux/X/input.c:406:16: error: returning ‘struct input_evnet *’ from a function with incompatible return type ‘struct input_event *’ [-Wincompatible-pointer-types]
  406 |         return ret;
      |                ^~~
```

Now it succeeds. 

Tested on Ubuntu