### PR TITLE
Add hint_border_color config option

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -96,6 +96,7 @@ static struct {
 
 	{ "hint_size", "20", "Hint size (range: 1-1000)", OPT_INT },
 	{ "hint_border_radius", "3", "Border radius.", OPT_INT },
+	{ "hint_border_color", "", "Hint border/outline color (rgba hex value, empty to disable).", OPT_STRING },
 
 	{ "hint_exit", "esc", "The exit key used for hint mode.", OPT_KEY },
 	{ "hint_undo", "backspace", "undo last selection step in one of the hint based modes.", OPT_KEY },

--- a/src/hint.c
+++ b/src/hint.c
@@ -232,7 +232,8 @@ void init_hints()
 	platform->init_hint(config_get("hint_bgcolor"),
 			    config_get("hint_fgcolor"),
 			    config_get_int("hint_border_radius"),
-			    config_get("hint_font"));
+			    config_get("hint_font"),
+			    config_get("hint_border_color"));
 }
 
 int hintspec_mode()

--- a/src/platform.h
+++ b/src/platform.h
@@ -74,7 +74,7 @@ struct platform {
 	void (*screen_clear)(screen_t scr);
 	void (*screen_list)(screen_t scr[MAX_SCREENS], size_t *n);
 
-	void (*init_hint)(const char *bg, const char *fg, int border_radius, const char *font_family);
+	void (*init_hint)(const char *bg, const char *fg, int border_radius, const char *font_family, const char *border_color);
 
 	/* 
 	 * Modifications to files passed into this function will interrupt

--- a/src/platform/linux/X/X.h
+++ b/src/platform/linux/X/X.h
@@ -98,7 +98,7 @@ void x_screen_get_dimensions(screen_t scr, int *w, int *h);
 void x_screen_draw_box(screen_t scr, int x, int y, int w, int h, const char *color);
 void x_screen_clear(screen_t scr);
 void x_screen_list(screen_t scr[MAX_SCREENS], size_t *n);
-void x_init_hint(const char *bg, const char *fg, int border_radius, const char *font_family);
+void x_init_hint(const char *bg, const char *fg, int border_radius, const char *font_family, const char *border_color);
 void x_hint_draw(struct screen *scr, struct hint *hints, size_t n);
 void x_scroll(int direction);
 void x_copy_selection();

--- a/src/platform/linux/X/hint.c
+++ b/src/platform/linux/X/hint.c
@@ -194,7 +194,7 @@ void x_hint_draw(struct screen *scr, struct hint *hints, size_t n)
 }
 
 void x_init_hint(const char *bgcol, const char *fgcol, int _border_radius,
-		 const char *_font_family)
+		 const char *_font_family, const char *border_color)
 {
 	static int init = 0;
 	size_t i;

--- a/src/platform/linux/wayland/hint.c
+++ b/src/platform/linux/wayland/hint.c
@@ -77,7 +77,7 @@ void way_hint_draw(struct screen *scr, struct hint *hints, size_t n)
 	scr->hints = create_surface(scr, 0, 0, scr->w, scr->h, 0);
 }
 
-void way_init_hint(const char *bg, const char *fg, int border_radius, const char *font)
+void way_init_hint(const char *bg, const char *fg, int border_radius, const char *font, const char *border_color)
 {
 	strncpy(bgcolor, bg, sizeof bgcolor);
 	strncpy(fgcolor, fg, sizeof fgcolor);

--- a/src/platform/linux/wayland/wayland.h
+++ b/src/platform/linux/wayland/wayland.h
@@ -119,7 +119,7 @@ void way_screen_get_dimensions(screen_t scr, int *w, int *h);
 void way_screen_draw_box(screen_t scr, int x, int y, int w, int h, const char *color);
 void way_screen_clear(screen_t scr);
 void way_screen_list(screen_t scr[MAX_SCREENS], size_t *n);
-void way_init_hint(const char *bg, const char *fg, int border_radius, const char *font_family);
+void way_init_hint(const char *bg, const char *fg, int border_radius, const char *font_family, const char *border_color);
 void way_hint_draw(struct screen *scr, struct hint *hints, size_t n);
 void way_scroll(int direction);
 void way_copy_selection();

--- a/src/platform/macos/hint.m
+++ b/src/platform/macos/hint.m
@@ -4,6 +4,7 @@ static float border_radius;
 
 static NSColor *bgColor;
 static NSColor *fgColor;
+static NSColor *borderColor;
 const char *font;
 
 
@@ -16,6 +17,19 @@ static void draw_hook(void *arg, NSView *view)
 		struct hint *h = &scr->hints[i];
 		macos_draw_box(scr, bgColor,
 				h->x, h->y, h->w, h->h, border_radius);
+
+		if (borderColor) {
+			float bx = h->x;
+			float by = scr->h - h->y - h->h;
+
+			NSBezierPath *bp = [NSBezierPath
+			    bezierPathWithRoundedRect:NSMakeRect(bx, by, (float)h->w, (float)h->h)
+					      xRadius:border_radius
+					      yRadius:border_radius];
+			[borderColor setStroke];
+			[bp setLineWidth:1.5];
+			[bp stroke];
+		}
 
 		macos_draw_text(scr, fgColor, font,
 				h->x, h->y, h->w, h->h, h->label);
@@ -31,10 +45,15 @@ void osx_hint_draw(struct screen *scr, struct hint *hints, size_t n)
 }
 
 void osx_init_hint(const char *bg, const char *fg, int _border_radius,
-	       const char *font_family)
+	       const char *font_family, const char *border_color)
 {
 	bgColor = nscolor_from_hex(bg);
 	fgColor = nscolor_from_hex(fg);
+
+	if (border_color && border_color[0])
+		borderColor = nscolor_from_hex(border_color);
+	else
+		borderColor = nil;
 
 	border_radius = (float)_border_radius;
 	font = font_family;

--- a/src/platform/macos/macos.h
+++ b/src/platform/macos/macos.h
@@ -117,7 +117,7 @@ void osx_screen_get_dimensions(screen_t scr, int *w, int *h);
 void osx_screen_draw_box(screen_t scr, int x, int y, int w, int h, const char *color);
 void osx_screen_clear(screen_t scr);
 void osx_screen_list(screen_t scr[MAX_SCREENS], size_t *n);
-void osx_init_hint(const char *bg, const char *fg, int border_radius, const char *font_family);
+void osx_init_hint(const char *bg, const char *fg, int border_radius, const char *font_family, const char *border_color);
 void osx_hint_draw(struct screen *scr, struct hint *hints, size_t n);
 void osx_scroll(int direction);
 void osx_copy_selection();

--- a/src/platform/windows/windows.c
+++ b/src/platform/windows/windows.c
@@ -134,7 +134,7 @@ static struct input_event *input_next_event(int timeout)
 	}
 }
 
-static void init_hint(const char *bg, const char *fg, int border_radius, const char *font_family)
+static void init_hint(const char *bg, const char *fg, int border_radius, const char *font_family, const char *border_color)
 {
 	//TODO: handle font family and border radius.
 	wn_screen_set_hintinfo(str_to_colorref(bg), str_to_colorref(fg));


### PR DESCRIPTION
## Summary

- Adds a new `hint_border_color` config option that draws a border/outline around hint labels
- When set to an rgba hex value (e.g. `#ffffff40`), hints render with a stroked rounded rect border
- When empty (default), no border is drawn — fully backward compatible

## Implementation

- Added `hint_border_color` as an `OPT_STRING` config entry (default: empty)
- Extended `init_hint` function pointer signature across all platforms (macOS, X11, Wayland, Windows) to accept the new `border_color` parameter
- Implemented border rendering on macOS using `NSBezierPath` with rounded rect stroke
- Linux and Windows platform stubs accept the parameter but don't render borders yet (can be added later)

## Usage

```
# ~/.config/warpd/config
hint_border_color: #ffffff40
```