### PR TITLE
query: Allow --query --normal composition and handle hint cancellation

### DIFF
--- a/src/mode-loop.c
+++ b/src/mode-loop.c
@@ -19,7 +19,14 @@ int mode_loop(int initial_mode, int oneshot, int record_history)
 			mode = MODE_NORMAL;
 			break;
 		case MODE_HINTSPEC:
-			hintspec_mode();
+			if (hintspec_mode() < 0)
+				goto exit;
+
+			if (!oneshot) {
+				ev = NULL;
+				mode = MODE_NORMAL;
+				continue;
+			}
 			break;
 		case MODE_NORMAL:
 			ev = normal_mode(ev, oneshot);

--- a/src/warpd.c
+++ b/src/warpd.c
@@ -141,6 +141,8 @@ static int click_flag = 0;
 static int x_flag = -1;
 static int y_flag = -1;
 static int record_flag = 0;
+static int query_flag = 0;
+static int normal_flag = 0;
 static int mode = 0;
 
 /* Platform entry points. */
@@ -251,6 +253,7 @@ int main(int argc, char *argv[])
 				foreground = 1;
 				break;
 			case 'q':
+				query_flag = 1;
 				mode = MODE_HINTSPEC;
 				oneshot_flag = 1;
 				break;
@@ -261,6 +264,7 @@ int main(int argc, char *argv[])
 				mode = MODE_GRID;
 				break;
 			case 259:
+				normal_flag = 1;
 				mode = MODE_NORMAL;
 				break;
 			case 261:
@@ -298,6 +302,12 @@ int main(int argc, char *argv[])
 			case '?':
 				return -1;
 		}
+	}
+
+	/* --query --normal: hint selection then enter normal mode */
+	if (query_flag && normal_flag) {
+		mode = MODE_HINTSPEC;
+		oneshot_flag = 0;
 	}
 
 	if (mode || oneshot_flag) {


### PR DESCRIPTION
## Summary

Two changes to `--query` behavior:

### 1. `--query --normal` composition (new feature)

When `--query` and `--normal` are both specified, warpd performs hint selection first, then transitions into normal mode instead of immediately exiting. This allows external tools to pipe custom hints into warpd and let the user interact using normal mode features (click, scroll, fine-tune cursor position, etc).

**`--query` alone** — behavior unchanged: hint selection → print coordinates → exit.  
**`--query --normal`** — hint selection → enter normal mode → user clicks/exits manually.

Use case: external scripts that detect clickable UI elements (via ML models, accessibility APIs, etc.) and pipe them as hints. After selecting a hint the user often wants to click, scroll, or adjust before committing — normal mode provides this naturally.

### 2. Fix hint cancellation in `--query` (bug fix)

Previously, `hintspec_mode()`'s return value was ignored. If the user cancelled hint selection (e.g. pressing Escape), the oneshot handler would still print the current cursor position. Now `--query` properly exits without output on cancellation.

### Changes

- **`src/warpd.c`** — Track `query_flag` and `normal_flag`. After getopt, if both are set, start in `MODE_HINTSPEC` with `oneshot_flag = 0`.
- **`src/mode-loop.c`** — Check `hintspec_mode()` return value; exit on cancellation. When `!oneshot`, transition to `MODE_NORMAL` after successful hint selection.